### PR TITLE
[bug/1798] Read local helm path from CUSTOM_HELM_PATH env var

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: helm
-version: 1.0.1
+version: 1.0.2
 
 authors:
   - William Harris <wharris@upscalews.com>

--- a/src/utils/binary_reference.cr
+++ b/src/utils/binary_reference.cr
@@ -2,7 +2,7 @@ require "./utils.cr"
 require "./system_information.cr"
 
 class BinaryReference 
-	@helm: String?
+  @helm : String?
 
 
 	def global_helm_installed?

--- a/src/utils/utils.cr
+++ b/src/utils/utils.cr
@@ -41,6 +41,7 @@ def binary_path
 end
 
 def local_helm_full_path
+  return ENV["CUSTOM_HELM_PATH"] if ENV["CUSTOM_HELM_PATH"]?
   "#{FileUtils.pwd}/#{binary_path}"
 end
 


### PR DESCRIPTION
## Issues: cncf/cnf-testsuite#1798

## Change summary

* Read `CUSTOM_HELM_PATH` env var for local helm path
* Bump `shard.yml` version to `1.0.2`
* Resolve unrelated GitHub annotation warning in the PR.

#### Before this change:
Local helm path was being read from the shard's current directory. This is within the `lib` dir when the shard is installed.

#### After this change:
Local helm path is read from `CUSTOM_HELM_PATH` env var if set and if the file is available.

#### Reason for this change
The cnf-testsuite project installs Helm in a path relative to the testsuite binary. To be able to find the custom helm binary, the shard needs to be informed about the custom helm path.
